### PR TITLE
ci: improve ci process to adhere to the correct GitHub Flow

### DIFF
--- a/.github/workflows/sematic-release.yml
+++ b/.github/workflows/sematic-release.yml
@@ -1,8 +1,9 @@
 name: semantic-release
 
-# this workflow only runs semantic-release, no testing, linting and such
-# it should be triggered only by pull request merge
-# for that master branch should be protected from direct push by branch protection rule
+# This workflow only runs semantic-release, no testing, linting and such.
+# It should be triggered only by merging up-to-date development branch.
+# To achieve that, master branch should have "Require a pull request before merging"
+# and "Require branches to be up to date before merging" protection rules enabled.
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches-ignore:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,19 @@
-name: pull-request
+name: test
 
 on:
+  push:
+    branches-ignore:
+      - master
   pull_request:
     branches:
       - master
-      - dev
 
 jobs:
-  pull-request:
+  test:
     runs-on: ubuntu-latest
 
     concurrency:
-      group: pull-request
+      group: test
       cancel-in-progress: false
 
     steps:


### PR DESCRIPTION
Make CI run tests on push to any branch, except master, and on pull request to master.